### PR TITLE
Fixed UBT output not printing to the Jenkins output log

### DIFF
--- a/src/unreal/UE4.groovy
+++ b/src/unreal/UE4.groovy
@@ -41,11 +41,11 @@ def RunCommand(def Command)
 {
 	if(isUnix())
 	{
-		sh(script: Command, returnStdout: true)
+		sh(script: Command)
 	}
 	else
 	{
-		bat(script: Command, returnStdout: true)
+		bat(script: Command)
 	}
 }
 


### PR DESCRIPTION
returnStdout returns stdout as a return value, and then the rest of the code just discards it.  removing it will cause jenkins to print the output of ubt.